### PR TITLE
Update org.apache.commons:commons-compress dependency to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>org.tukaani</groupId>


### PR DESCRIPTION
Fixes https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-460507

Tests were run inside this repository, and in embedded-database-spring-test.