### PR TITLE
Allow running under root on Linux when unshare is available

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 13]
+        java: [8, 11, 13, 14]
     steps:
     - name: Checkout project
       uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -150,17 +150,21 @@ Since `PostgreSQL 10.0`, there are additional artifacts with `alpine-lite` suffi
 
 ### Process [/tmp/embedded-pg/PG-XYZ/bin/initdb, ...] failed
 
-Try to remove `/tmp/embedded-pg/PG-XYZ` directory containing temporary binaries of the embedded postgres database. That should solve the problem. 
+Check the console output for an `initdb: cannot be run as root` message. If the error is present, try to upgrade to a newer version of the library (1.2.8+), or ensure the build process to be running as a non-root user.
+
+If the error is not present, try to clean up the `/tmp/embedded-pg/PG-XYZ` directory containing temporary binaries of the embedded database. 
 
 ### Running tests on Windows does not work
 
-You probably need to install the [Microsoft Visual C++ 2013 Redistributable Package](https://support.microsoft.com/en-us/help/3179560/update-for-visual-c-2013-and-visual-c-redistributable-package). The version 2013 is important, installation of other versions will not help. More detailed is the problem discussed [here](https://github.com/opentable/otj-pg-embedded/issues/65).
+You probably need to install [Microsoft Visual C++ 2013 Redistributable Package](https://support.microsoft.com/en-us/help/3179560/update-for-visual-c-2013-and-visual-c-redistributable-package). The version 2013 is important, installation of other versions will not help. More detailed is the problem discussed [here](https://github.com/opentable/otj-pg-embedded/issues/65).
 
-### Running tests inside Docker does not work
+### Running tests in Docker does not work
 
-Running build inside Docker is fully supported, including Alpine Linux. But you must keep in mind that the **PostgreSQL database must be run under a non-root user**. Otherwise, the database does not start and fails with an error.
+Running builds inside a Docker container is fully supported, including Alpine Linux. However, PostgreSQL has a restriction the database process must run under a non-root user. Otherwise, the database does not start and fails with an error.  
 
-So be sure to use a docker image that uses a non-root user, or you can use any of the following Dockerfiles to prepare your own image.
+So be sure to use a docker image that uses a non-root user. Or, since version `1.2.8` you can run the docker container with `--privileged` option, which allows taking advantage of `unshare` command to run the database process in a separate namespace.
+
+Below are some examples of how to prepare a docker image running with a non-root user:
 
 <details>
   <summary>Standard Dockerfile</summary>

--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.6</version>
+            <version>3.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.tukaani</groupId>
@@ -124,29 +124,29 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.11</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>6.0.8</version>
+            <version>6.5.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.6.3</version>
+            <version>4.0.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
+            <version>42.2.14</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.3.2</version>
+            <version>5.6.2</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -166,13 +166,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.30</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.13.0</version>
+            <version>3.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -181,7 +181,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.8</version>
+                <version>3.13.0</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>
@@ -194,13 +194,13 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>5.6.1</version>
+                        <version>6.25.0</version>
                         <scope>compile</scope>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>5.6.1</version>
+                        <version>6.25.0</version>
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>
@@ -216,7 +216,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -229,7 +229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -263,7 +263,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/io/zonky/test/db/postgres/util/LinuxUtils.java
+++ b/src/main/java/io/zonky/test/db/postgres/util/LinuxUtils.java
@@ -22,13 +22,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -38,8 +34,7 @@ public final class LinuxUtils {
     private static final Logger logger = LoggerFactory.getLogger(LinuxUtils.class);
 
     private static final String DISTRIBUTION_NAME = resolveDistributionName();
-
-    private static final boolean UNSHARE_USEABLE = unshareUseable();
+    private static final boolean UNSHARE_AVAILABLE = unshareAvailable();
 
     private LinuxUtils() {}
 
@@ -47,7 +42,9 @@ public final class LinuxUtils {
         return DISTRIBUTION_NAME;
     }
 
-    public static boolean isUnshareUseable() { return UNSHARE_USEABLE; }
+    public static boolean isUnshareAvailable() {
+        return UNSHARE_AVAILABLE;
+    }
 
     private static String resolveDistributionName() {
         if (!SystemUtils.IS_OS_LINUX) {
@@ -95,46 +92,36 @@ public final class LinuxUtils {
         }
     }
 
-    private static boolean unshareUseable() {
-        if (SystemUtils.IS_OS_LINUX) {
-            int uid;
-            try {
-                Class<?> c = Class.forName("com.sun.security.auth.module.UnixSystem");
-                Object o = c.getDeclaredConstructor().newInstance();
-                Method method = c.getDeclaredMethod("getUid");
-                uid = ((Number) method.invoke(o)).intValue();
-            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException |
-                    NoSuchMethodException | InvocationTargetException e) {
+    private static boolean unshareAvailable() {
+        if (!SystemUtils.IS_OS_LINUX) {
+            return false;
+        }
+
+        try {
+            Class<?> clazz = Class.forName("com.sun.security.auth.module.UnixSystem");
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+            Method method = clazz.getDeclaredMethod("getUid");
+            int uid = ((Number) method.invoke(instance)).intValue();
+
+            if (uid != 0) {
                 return false;
             }
-            if (uid == 0) {
-                final List<String> command = new ArrayList<>();
-                command.addAll(Arrays.asList(
-                        "unshare", "-U",
-                        "id", "-u"
-                ));
-                final ProcessBuilder builder = new ProcessBuilder(command);
-                final Process process;
-                try {
-                    process = builder.start();
-                } catch (IOException e) {
-                    return false;
-                }
-                BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                try {
-                    process.waitFor();
-                } catch (InterruptedException e) {
-                    return false;
-                }
-                try {
-                    if (process.exitValue() == 0 && br.readLine() != "0") {
-                        return true;
-                    }
-                } catch (IOException e) {
-                    return false;
+
+            ProcessBuilder builder = new ProcessBuilder();
+            builder.command("unshare", "-U", "id", "-u");
+
+            Process process = builder.start();
+            process.waitFor();
+
+            try (BufferedReader outputReader = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
+                if (process.exitValue() == 0 && !"0".equals(outputReader.readLine())) {
+                    return true;
                 }
             }
+
+            return false;
+        } catch (Exception e) {
+            return false;
         }
-        return false;
     }
 }


### PR DESCRIPTION
I've reworked the `unshare` parts from #23 so that we test once on initialization that `unshare` is useable when running as root on Linux. This should avoid any cryptic errors when `unshare` is unavailable.

I've also reworked the runner to execute the `postgres` binary directly as opposed to being backgrounded by `pg_ctl`. This has the advantage of preventing orphan `postgres` in the event that cleanup fails as the `postgres` process should effectively be a child of the java module which would get killed at the same time as the java module.