### PR TITLE
Remove duplicates of resource url in DefaultPostgresBinaryResolver

### DIFF
--- a/src/main/java/io/zonky/test/db/postgres/embedded/DefaultPostgresBinaryResolver.java
+++ b/src/main/java/io/zonky/test/db/postgres/embedded/DefaultPostgresBinaryResolver.java
@@ -72,6 +72,7 @@ public class DefaultPostgresBinaryResolver implements PgBinaryResolver {
         logger.trace("Searching for postgres binaries - location: '{}'", resourceLocation);
         ClassLoader classLoader = DefaultPostgresBinaryResolver.class.getClassLoader();
         List<URL> urls = Collections.list(classLoader.getResources(resourceLocation));
+        urls = new java.util.ArrayList<>(new java.util.HashSet<>(urls));
 
         if (urls.size() > 1) {
             logger.error("Detected multiple binaries of the same architecture: {}", urls);


### PR DESCRIPTION
After an upgrade of Coursier(After upgrade of sbt 1.3.10 to 1.3.11) the DefaultPostgresBinaryResolver starts to gets two identical urls from the classLoader when looking for binaries. I don't know the root cause of this or what has changed this behavior.

The problem is that this will trigger an IllegalStateException("Duplicate postgres binaries"). As they are identical and thereby point to the same binary, my assumption is that it fine to just remove any duplicates.

This is the url that I found 2 copies of:
jar:file:/Users/.../Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-amd64/10.11.0/embedded-postgres-binaries-darwin-amd64-10.11.0.jar!/postgres-darwin-x86_64.txz