### PR TITLE
Add tests for Junit 5 and fix PreparedDbExtension instance(non-static) lifecycle.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 13, 14]
+        java: [8, 11, 13, 14, 15]
     steps:
     - name: Checkout project
       uses: actions/checkout@v1

--- a/pom.xml
+++ b/pom.xml
@@ -158,9 +158,21 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.6.2</version>
+            <version>5.7.0</version>
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -179,6 +191,10 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>3.13.0</version>
@@ -239,7 +255,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/zonky/test/db/postgres/junit5/EmbeddedPostgresExtension.java
+++ b/src/main/java/io/zonky/test/db/postgres/junit5/EmbeddedPostgresExtension.java
@@ -14,7 +14,7 @@
 package io.zonky.test.db.postgres.junit5;
 
 import io.zonky.test.db.postgres.embedded.DatabasePreparer;
-import org.junit.rules.TestRule;
+import org.junit.jupiter.api.extension.Extension;
 
 public final class EmbeddedPostgresExtension {
 
@@ -28,7 +28,7 @@ public final class EmbeddedPostgresExtension {
     }
 
     /**
-     * Returns a {@link TestRule} to create a Postgres cluster, shared amongst all test cases in this JVM.
+     * Returns a {@link Extension} to create a Postgres cluster, shared amongst all test cases in this JVM.
      * The rule contributes Config switches to configure each test case to get its own database.
      */
     public static PreparedDbExtension preparedDatabase(DatabasePreparer preparer)

--- a/src/test/java/io/zonky/test/db/postgres/embedded/EmbeddedPostgresTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/embedded/EmbeddedPostgresTest.java
@@ -13,22 +13,23 @@
  */
 package io.zonky.test.db.postgres.embedded;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class EmbeddedPostgresTest
 {
-    @Rule
-    public TemporaryFolder tf = new TemporaryFolder();
+    @TempDir
+    public Path tf;
 
     @Test
     public void testEmbeddedPg() throws Exception
@@ -47,7 +48,7 @@ public class EmbeddedPostgresTest
     public void testEmbeddedPgCreationWithNestedDataDirectory() throws Exception
     {
         try (EmbeddedPostgres pg = EmbeddedPostgres.builder()
-                .setDataDirectory(tf.newFolder("data-dir-parent") + "/data-dir")
+                .setDataDirectory(Files.createDirectories(tf.resolve("data-dir-parent").resolve("data-dir")))
                 .start()) {
             // nothing to do
         }

--- a/src/test/java/io/zonky/test/db/postgres/junit/ConnectConfigTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/ConnectConfigTest.java
@@ -1,7 +1,7 @@
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit;
 
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.PreparedDbRule;
+import io.zonky.test.db.postgres.embedded.ConnectionInfo;
+import io.zonky.test.db.postgres.embedded.DatabasePreparer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.postgresql.ds.common.BaseDataSource;

--- a/src/test/java/io/zonky/test/db/postgres/junit/FlywayPreparerTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/FlywayPreparerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import io.zonky.test.db.postgres.embedded.FlywayPreparer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FlywayPreparerTest {
+    @Rule
+    public PreparedDbRule db = EmbeddedPostgresRules.preparedDatabase(FlywayPreparer.forClasspathLocation("db/testing"));
+
+    @Test
+    public void testTablesMade() throws Exception {
+        try (Connection c = db.getTestDatabase().getConnection();
+                Statement s = c.createStatement()) {
+            ResultSet rs = s.executeQuery("SELECT * FROM foo");
+            rs.next();
+            assertEquals("bar", rs.getString(1));
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit/IsolationTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/IsolationTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -19,9 +19,6 @@ import java.sql.Statement;
 
 import org.junit.Rule;
 import org.junit.Test;
-
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.SingleInstancePostgresRule;
 
 public class IsolationTest
 {

--- a/src/test/java/io/zonky/test/db/postgres/junit/LiquibasePreparerContextTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/LiquibasePreparerContextTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit;
+
+import io.zonky.test.db.postgres.embedded.LiquibasePreparer;
+import liquibase.Contexts;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+public class LiquibasePreparerContextTest {
+
+    @Rule
+    public PreparedDbRule db = EmbeddedPostgresRules.preparedDatabase(LiquibasePreparer.forClasspathLocation("liqui/master-test.xml", new Contexts("test")));
+
+    @Test
+    public void testEmptyTables() throws Exception {
+        try (Connection c = db.getTestDatabase().getConnection();
+             Statement s = c.createStatement()) {
+            ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM foo");
+            rs.next();
+            assertEquals(0, rs.getInt(1));
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit/LiquibasePreparerTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/LiquibasePreparerTest.java
@@ -11,10 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit;
 
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.PreparedDbRule;
+import io.zonky.test.db.postgres.embedded.LiquibasePreparer;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/io/zonky/test/db/postgres/junit/PreparedDbCustomizerTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/PreparedDbCustomizerTest.java
@@ -11,10 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit;
 
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.PreparedDbRule;
+import io.zonky.test.db.postgres.embedded.DatabasePreparer;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/io/zonky/test/db/postgres/junit/PreparedDbTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/PreparedDbTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -24,11 +24,11 @@ import java.sql.Statement;
 
 import javax.sql.DataSource;
 
+import io.zonky.test.db.postgres.embedded.ConnectionInfo;
+import io.zonky.test.db.postgres.embedded.DatabaseConnectionPreparer;
+import io.zonky.test.db.postgres.embedded.DatabasePreparer;
 import org.junit.Rule;
 import org.junit.Test;
-
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.PreparedDbRule;
 
 public class PreparedDbTest {
 

--- a/src/test/java/io/zonky/test/db/postgres/junit/SingleInstanceRuleTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit/SingleInstanceRuleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SingleInstanceRuleTest
+{
+    @Rule
+    public SingleInstancePostgresRule epg = EmbeddedPostgresRules.singleInstance();
+
+    @Test
+    public void testRule() throws Exception {
+        try (Connection c = epg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+            Statement s = c.createStatement();
+            ResultSet rs = s.executeQuery("SELECT 1");
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertFalse(rs.next());
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/ConnectConfigTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/ConnectConfigTest.java
@@ -1,0 +1,53 @@
+package io.zonky.test.db.postgres.junit5;
+
+import io.zonky.test.db.postgres.embedded.ConnectionInfo;
+import io.zonky.test.db.postgres.embedded.DatabasePreparer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.postgresql.ds.common.BaseDataSource;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConnectConfigTest {
+
+    private final CapturingDatabasePreparer preparer = new CapturingDatabasePreparer();
+
+    @RegisterExtension
+    public PreparedDbExtension db = EmbeddedPostgresExtension.preparedDatabase(preparer)
+            .customize(builder -> builder.setConnectConfig("connectTimeout", "20"));
+
+    @Test
+    public void test() throws SQLException {
+        ConnectionInfo connectionInfo = db.getConnectionInfo();
+
+        Map<String, String> properties = connectionInfo.getProperties();
+        assertEquals(1, properties.size());
+        assertEquals("20", properties.get("connectTimeout"));
+
+        BaseDataSource testDatabase = (BaseDataSource) db.getTestDatabase();
+        assertEquals("20", testDatabase.getProperty("connectTimeout"));
+
+        BaseDataSource preparerDataSource = (BaseDataSource) preparer.getDataSource();
+        assertEquals("20", preparerDataSource.getProperty("connectTimeout"));
+    }
+
+    private class CapturingDatabasePreparer implements DatabasePreparer {
+
+        private DataSource dataSource;
+
+        @Override
+        public void prepare(DataSource ds) {
+            if (dataSource != null)
+                throw new IllegalStateException("database preparer has been called multiple times");
+            dataSource = ds;
+        }
+
+        public DataSource getDataSource() {
+            return dataSource;
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/DatabaseLifecycleTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/DatabaseLifecycleTest.java
@@ -1,0 +1,68 @@
+package io.zonky.test.db.postgres.junit5;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class DatabaseLifecycleTest {
+
+    @RegisterExtension
+    public static PreparedDbExtension staticExtension = EmbeddedPostgresExtension.preparedDatabase(ds -> {});
+
+    @RegisterExtension
+    public PreparedDbExtension instanceExtension = EmbeddedPostgresExtension.preparedDatabase(ds -> {});
+
+    @Test
+    @Order(1)
+    public void testCreate1() throws Exception
+    {
+        createTable(staticExtension, "table1");
+        createTable(instanceExtension, "table2");
+    }
+
+    @Test
+    @Order(2)
+    public void testCreate2() throws Exception
+    {
+        assertTrue(existsTable(staticExtension, "table1"));
+        assertFalse(existsTable(instanceExtension, "table2"));
+    }
+
+    @Test
+    @Order(3)
+    public void testCreate3() throws Exception
+    {
+        assertTrue(existsTable(staticExtension, "table1"));
+        assertFalse(existsTable(instanceExtension, "table2"));
+    }
+
+    private void createTable(PreparedDbExtension extension, String table) throws SQLException
+    {
+        try (Connection connection = extension.getTestDatabase().getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(String.format("CREATE TABLE public.%s (a INTEGER)", table));
+        }
+    }
+
+    private boolean existsTable(PreparedDbExtension extension, String table) throws SQLException
+    {
+        try (Connection connection = extension.getTestDatabase().getConnection();
+             Statement statement = connection.createStatement()) {
+            String query = String.format("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '%s')", table);
+            ResultSet resultSet = statement.executeQuery(query);
+            resultSet.next();
+            return resultSet.getBoolean(1);
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/FlywayPreparerTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/FlywayPreparerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import io.zonky.test.db.postgres.embedded.FlywayPreparer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class FlywayPreparerTest {
+    @RegisterExtension
+    public PreparedDbExtension db = EmbeddedPostgresExtension.preparedDatabase(FlywayPreparer.forClasspathLocation("db/testing"));
+
+    @Test
+    public void testTablesMade() throws Exception {
+        try (Connection c = db.getTestDatabase().getConnection();
+                Statement s = c.createStatement()) {
+            ResultSet rs = s.executeQuery("SELECT * FROM foo");
+            rs.next();
+            assertEquals("bar", rs.getString(1));
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/IsolationTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/IsolationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit5;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class IsolationTest
+{
+    @RegisterExtension
+    public SingleInstancePostgresExtension pg1 = EmbeddedPostgresExtension.singleInstance();
+
+    @RegisterExtension
+    public SingleInstancePostgresExtension pg2 = EmbeddedPostgresExtension.singleInstance();
+
+    @Test
+    public void testIsolation() throws Exception
+    {
+        try (Connection c = getConnection(pg1)) {
+            makeTable(c);
+            try (Connection c2 = getConnection(pg2)) {
+                makeTable(c2);
+            }
+        }
+    }
+
+    private void makeTable(Connection c) throws SQLException
+    {
+        Statement s = c.createStatement();
+        s.execute("CREATE TABLE public.foo (a INTEGER)");
+    }
+
+    private Connection getConnection(SingleInstancePostgresExtension epg) throws SQLException
+    {
+        return epg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/LiquibasePreparerContextTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/LiquibasePreparerContextTest.java
@@ -11,24 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit5;
 
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.PreparedDbRule;
+import io.zonky.test.db.postgres.embedded.LiquibasePreparer;
 import liquibase.Contexts;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LiquibasePreparerContextTest {
 
-    @Rule
-    public PreparedDbRule db = EmbeddedPostgresRules.preparedDatabase(LiquibasePreparer.forClasspathLocation("liqui/master-test.xml", new Contexts("test")));
+    @RegisterExtension
+    public PreparedDbExtension db = EmbeddedPostgresExtension.preparedDatabase(LiquibasePreparer.forClasspathLocation("liqui/master-test.xml", new Contexts("test")));
 
     @Test
     public void testEmptyTables() throws Exception {

--- a/src/test/java/io/zonky/test/db/postgres/junit5/LiquibasePreparerTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/LiquibasePreparerTest.java
@@ -11,23 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit5;
 
-import static org.junit.Assert.assertEquals;
+import io.zonky.test.db.postgres.embedded.LiquibasePreparer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
-import org.junit.Rule;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.PreparedDbRule;
+public class LiquibasePreparerTest {
 
-public class FlywayPreparerTest {
-    @Rule
-    public PreparedDbRule db = EmbeddedPostgresRules.preparedDatabase(FlywayPreparer.forClasspathLocation("db/testing"));
+    @RegisterExtension
+    public PreparedDbExtension db = EmbeddedPostgresExtension.preparedDatabase(LiquibasePreparer.forClasspathLocation("liqui/master.xml"));
 
     @Test
     public void testTablesMade() throws Exception {

--- a/src/test/java/io/zonky/test/db/postgres/junit5/PreparedDbCustomizerTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/PreparedDbCustomizerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit5;
+
+import io.zonky.test.db.postgres.embedded.DatabasePreparer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class PreparedDbCustomizerTest {
+
+    private static final DatabasePreparer EMPTY_PREPARER = ds -> {};
+
+    @RegisterExtension
+    public PreparedDbExtension dbA1 = EmbeddedPostgresExtension.preparedDatabase(EMPTY_PREPARER);
+    @RegisterExtension
+    public PreparedDbExtension dbA2 = EmbeddedPostgresExtension.preparedDatabase(EMPTY_PREPARER).customize(builder -> {});
+    @RegisterExtension
+    public PreparedDbExtension dbA3 = EmbeddedPostgresExtension.preparedDatabase(EMPTY_PREPARER).customize(builder -> builder.setPGStartupWait(Duration.ofSeconds(10)));
+    @RegisterExtension
+    public PreparedDbExtension dbB1 = EmbeddedPostgresExtension.preparedDatabase(EMPTY_PREPARER).customize(builder -> builder.setPGStartupWait(Duration.ofSeconds(11)));
+    @RegisterExtension
+    public PreparedDbExtension dbB2 = EmbeddedPostgresExtension.preparedDatabase(EMPTY_PREPARER).customize(builder -> builder.setPGStartupWait(Duration.ofSeconds(11)));
+
+    @Test
+    public void testCustomizers() {
+        int dbA1Port = dbA1.getConnectionInfo().getPort();
+        int dbA2Port = dbA2.getConnectionInfo().getPort();
+        int dbA3Port = dbA3.getConnectionInfo().getPort();
+
+        assertEquals(dbA1Port, dbA2Port);
+        assertEquals(dbA1Port, dbA3Port);
+
+        int dbB1Port = dbB1.getConnectionInfo().getPort();
+        int dbB2Port = dbB2.getConnectionInfo().getPort();
+
+        assertEquals(dbB1Port, dbB2Port);
+
+        assertNotEquals(dbA1Port, dbB2Port);
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/PreparedDbTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/PreparedDbTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zonky.test.db.postgres.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.sql.DataSource;
+
+import io.zonky.test.db.postgres.embedded.ConnectionInfo;
+import io.zonky.test.db.postgres.embedded.DatabaseConnectionPreparer;
+import io.zonky.test.db.postgres.embedded.DatabasePreparer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class PreparedDbTest {
+
+    private final DatabasePreparer prepA = new SimplePreparer("a");
+    private final DatabasePreparer prepB = new SimplePreparer("b");
+
+    @RegisterExtension
+    public PreparedDbExtension dbA1 = EmbeddedPostgresExtension.preparedDatabase(prepA);
+    @RegisterExtension
+    public PreparedDbExtension dbA2 = EmbeddedPostgresExtension.preparedDatabase(prepA);
+    @RegisterExtension
+    public PreparedDbExtension dbB1 = EmbeddedPostgresExtension.preparedDatabase(prepB);
+
+    @Test
+    public void testDbs() throws Exception {
+        try (Connection c = dbA1.getTestDatabase().getConnection();
+                Statement stmt = c.createStatement()) {
+            commonAssertion(stmt);
+        }
+        try (Connection c = dbA2.getTestDatabase().getConnection();
+                PreparedStatement stmt = c.prepareStatement("SELECT count(1) FROM a")) {
+            ResultSet rs = stmt.executeQuery();
+            rs.next();
+            assertEquals(0, rs.getInt(1));
+        }
+        try (Connection c = dbB1.getTestDatabase().getConnection();
+                PreparedStatement stmt = c.prepareStatement("SELECT * FROM b")) {
+            stmt.execute();
+        }
+    }
+
+    private void commonAssertion(final Statement stmt) throws SQLException {
+        stmt.execute("INSERT INTO a VALUES(1)");
+        ResultSet rs = stmt.executeQuery("SELECT COUNT(1) FROM a");
+        rs.next();
+        assertEquals(1, rs.getInt(1));
+    }
+
+    @Test
+    public void testEquivalentAccess() throws SQLException {
+        ConnectionInfo dbInfo = dbA1.getConnectionInfo();
+        DataSource dataSource = dbA1.getTestDatabase();
+        try (Connection c = dataSource.getConnection(); Statement stmt = c.createStatement()) {
+            commonAssertion(stmt);
+            assertEquals(dbInfo.getUser(), c.getMetaData().getUserName());
+        }
+    }
+
+    @Test
+    public void testDbUri() throws Exception {
+        try (Connection c = DriverManager.getConnection(dbA1.getDbProvider().createDatabase());
+             Statement stmt = c.createStatement()) {
+            commonAssertion(stmt);
+        }
+    }
+
+    static class SimplePreparer implements DatabaseConnectionPreparer {
+        private final String name;
+
+        public SimplePreparer(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void prepare(Connection conn) throws SQLException {
+            try (PreparedStatement stmt = conn.prepareStatement(String.format(
+                    "CREATE TABLE %s (foo int)", name))) {
+                stmt.execute();
+            }
+        }
+    }
+}

--- a/src/test/java/io/zonky/test/db/postgres/junit5/SingleInstanceRuleTest.java
+++ b/src/test/java/io/zonky/test/db/postgres/junit5/SingleInstanceRuleTest.java
@@ -11,26 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zonky.test.db.postgres.embedded;
+package io.zonky.test.db.postgres.junit5;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
-import org.junit.Rule;
-import org.junit.Test;
-
-import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
-import io.zonky.test.db.postgres.junit.SingleInstancePostgresRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SingleInstanceRuleTest
 {
-    @Rule
-    public SingleInstancePostgresRule epg = EmbeddedPostgresRules.singleInstance();
+    @RegisterExtension
+    public SingleInstancePostgresExtension epg = EmbeddedPostgresExtension.singleInstance();
 
     @Test
     public void testRule() throws Exception {


### PR DESCRIPTION
This is mostly just a port of the Junit 4 tests to Junit 5.