### PR TITLE
Readme: Docker non-root example for gitlab runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,5 +196,19 @@ Below are some examples of how to prepare a docker image running with a non-root
 
 </details>
 
+<details>
+  <summary>Gitlab runner Docker executor</summary>
+
+  Configure Docker container to run in privileged mode as described [here](https://docs.gitlab.com/runner/executors/docker.html#use-docker-in-docker-with-privileged-mode).
+
+  ```
+  [[runners]]
+    executor = "docker"
+    [runners.docker]
+      privileged = true
+  ```
+
+</details>
+
 ## License
 The project is released under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0.html).


### PR DESCRIPTION
When a Gitlab runner with docker executor is used it needs an adjustment to
run in privileged mode.