### PR TITLE
ensure unshare user has a valid name

### DIFF
--- a/src/main/java/io/zonky/test/db/postgres/util/LinuxUtils.java
+++ b/src/main/java/io/zonky/test/db/postgres/util/LinuxUtils.java
@@ -115,7 +115,12 @@ public final class LinuxUtils {
 
             try (BufferedReader outputReader = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
                 if (process.exitValue() == 0 && !"0".equals(outputReader.readLine())) {
-                    return true;
+                    builder.command("unshare", "-U", "id", "-un");
+                    Process nameprocess = builder.start();
+                    nameprocess.waitFor();
+                    if (nameprocess.exitValue() == 0) {
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
Prevents unshare wrapper from being used if the unshare wrapper user does not have a valid name as in #81.