### PR TITLE
Upgrade org.apache.commons:commons-compress to 1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.tukaani</groupId>


### PR DESCRIPTION
Fixes Infinite loop Affecting org.apache.commons:commons-compress package, versions [1.3,1.26.0)
See https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254296