### PR TITLE
chore: bump commons-lang3 to align with liquibase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <commons-codec.version>1.17.1</commons-codec.version>
         <commons-compress.version>1.26.2</commons-compress.version>
         <commons-io.version>2.16.1</commons-io.version>
-        <commons-lang3.version>3.15.0</commons-lang3.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
         <flyway.version>9.22.3</flyway.version>
         <junit5.version>5.10.3</junit5.version>
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
The newest version of liquibase has a version of `commons-lang3` that conflicts with the version here. This PR lines them up. 

https://github.com/liquibase/liquibase/blob/master/pom.xml#L72