### PR TITLE
Upgraded commons-lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <commons-codec.version>1.17.1</commons-codec.version>
         <commons-compress.version>1.26.2</commons-compress.version>
         <commons-io.version>2.16.1</commons-io.version>
-        <commons-lang3.version>3.15.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <flyway.version>9.22.3</flyway.version>
         <junit5.version>5.10.5</junit5.version>
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
Upgraded commons-lang3 to 3.18.0 to fix CVE CVE-2025-48924

https://github.com/zonkyio/embedded-postgres/issues/156