### PR TITLE
Update EmbeddedPostgres.java

### DIFF
--- a/src/main/java/io/zonky/test/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/io/zonky/test/db/postgres/embedded/EmbeddedPostgres.java
@@ -97,7 +97,7 @@ public class EmbeddedPostgres implements Closeable
     private final UUID instanceId = UUID.randomUUID();
     private final int port;
     private final AtomicBoolean started = new AtomicBoolean();
-    private final AtomicBoolean closed = new AtomicBoolean();
+    private final AtomicBoolean dbClosed = new AtomicBoolean();
 
     private final Map<String, String> postgresConfig;
     private final Map<String, String> localeConfig;
@@ -397,7 +397,7 @@ public class EmbeddedPostgres implements Closeable
     @Override
     public void close() throws IOException
     {
-        if (closed.getAndSet(true)) {
+        if (dbClosed.getAndSet(true)) {
             return;
         }
         final StopWatch watch = new StopWatch();


### PR DESCRIPTION
Renaming the `closed` property fixes an issue where the embedded server does not close properly in a Spring context.  I suspect Spring frameworks is touching it somehow.